### PR TITLE
Remediations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# connector-sympa
+
+## Change Log
+
++ **1.0.2** - Initial development (2021/06/30)
++ **1.0.5** - Removed IS_OWNER and IS_SUBSCRIBER from schema. Fixed DOMAIN attribute. Made configuration file optional by allowing setting on the Resource Configuration Page

--- a/README.md
+++ b/README.md
@@ -1,62 +1,169 @@
-# Sympa connector for Midpoint Integration
-
-Open source Midpoint Identity Management Connector for the [Sympa List Server](https://www.sympa.org/).
-
-This connector is based on and leverages the [Exclamation Labs Connector Base Framework](https://github.com/ExclamationLabs/connector-base)
-
-## Overview
-
-This software is licensed under the terms of [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) 
-
-This connector uses the Trusted Application interface to interact with a Sympa SOAP service. This interface is described 
-in the Sympa Administration Manual [here](https://sympa-community.github.io/manual/customize/soap-api.html#trust-remote-applications)  
-
-The current version integrates with a Sympa SOAP service to allow a Midpoint instance to perform the 
-following operations: 
-
-- Create A List
-- Close A List
-- Get all lists 
-- Get one list by list name or list address.
-
-## Getting Started
-
-- After installing the Sympa Server you will need to create or modify the *trusted_application.conf* file to produce an 
-  application name, and an application password that can be used to configure the connection.
-  
-- Download the latest version of the connector from 
-- Install and configure the connector into your midpoint instance
-
-- Create a resource for each Sympa instance that you wish to control
-
-## Midpoint Configuration
-
-- Copy the compiled connector jar file to the *icf-connectors* subdirectory of your Midpoint instance. This is the connector library folder.
-
-- Restart midPoint. 
-
-- Within Midpoint create a resource type definition for each Sympa Instance you want to control. Each instance will need its onw resource configuration file. Make sure to set the fully qualified file location of the configuration file.
+# Sympa Connector for Midpoint
 
 
-## Configuration Properties
+# 1	Overview
 
-The midpoint IAM must supply the following configuration properties for the connector to operate. No value can be blank or null.
-See https://github.com/ExclamationLabs/connector-sympa/blob/main/src/main/resources/sympa-config-example.properties 
-for an example configuration file. 
-  
-- **app.name** is the trusted application name specified in the target Sympa server's **trusted_applications.conf** file. 
+This software is licensed under the terms of [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-- **app.password** is the trusted application password specified by the Sympa server's administrator and whose md5 hash 
-  is stored in the **trusted_applications.conf** file.
-  
-- **list.master** is the email address of the list master who is permitted to perform operations executed by the connector. 
-  The Sympa administrator should grant the necessary permissions to the email address specified here.
-  
-- **sympa.domain.url** is the url of the Sympa Service you which to control. This url endpoint is typically specified as 
-  the port location in the service WSDL.
+This connector uses the Trusted Application interface to interact with a Sympa SOAP service. This interface is described in the Sympa Administration Manual [here](https://sympa-community.github.io/manual/customize/soap-api.html#trust-remote-applications)
+
+The current version integrates with a Sympa SOAP service to allow a Midpoint instance to perform the following operations:
 
 
-- **sympa.domain.wsdl** is the url of the Sympa server's WSDL file. This url should contain the same fully qualified 
-  host name as the **sympa.domain.url** property  
 
-- **CONNECTOR_BASE_CONFIGURATION_ACTIVE** This configuration item originates from the base connector and should tbe set to Y
+* Create A List
+* Close A List
+* Get all lists
+* Get one list by list name or list address.
+
+
+# 2	Getting Started
+
+
+
+* After installing the Sympa Server you will need to create or modify the _trusted_application.conf_ file to produce an application name, and an application password that can be used to configure the connection.
+* Download the latest version of the connector from this repository.
+* Install and configure the connector into your midpoint instance
+* Create a resource for each Sympa instance that you wish to control
+
+
+# 3	Midpoint Setup
+
+
+
+* Copy the compiled connector jar file to the _icf-connectors_ subdirectory of your Midpoint instance. This is the connector library folder.
+* Restart midPoint.
+* Within Midpoint create a resource type definition for each Sympa Instance you want to control. Each instance will need its own resource configuration. Make sure to set the fully qualified file location of the configuration file.
+
+
+# 4	Connector Configuration
+
+The connector can be configured by entering the parameters in a property file or by entering the parameters on the Resource Configuration Page.
+
+The following configuration properties are necessary for the connector to operate. No value can be blank or null. See [https://github.com/ExclamationLabs/connector-sympa/blob/main/src/main/resources/sympa-config-example.properties](https://github.com/ExclamationLabs/connector-sympa/blob/main/src/main/resources/sympa-config-example.properties) for an example configuration file.
+
+
+
+* **app.name** is the trusted application name specified in the target Sympa server's trusted_applications.conf file.
+* **app.password** is the trusted application password specified by the Sympa server's administrator and whose md5 hash is stored in the trusted_applications.conf file.
+* **list.master** is the email address of the list master who is permitted to perform operations executed by the connector. The Sympa administrator should grant the necessary permissions to the email address specified here.
+* **sympa.domain.url** is the url of the Sympa Service you which to control. This url endpoint is typically specified as the port location in the service WSDL.
+* **sympa.domain.wsdl** is the url of the Sympa server's WSDL file. This url should contain the same fully qualified host name as the sympa.domain.url property
+* **CONNECTOR_BASE_CONFIGURATION_ACTIVE** This configuration item originates from the base connector and should be set to Y
+
+
+# 5	Connector Schema
+
+The connector schema consists of the following attributes.
+
+
+<table>
+  <tr>
+   <td>Attribute
+   </td>
+   <td>IN
+   </td>
+   <td>OUT
+   </td>
+   <td>Required
+   </td>
+   <td>Description
+   </td>
+  </tr>
+  <tr>
+   <td>LIST_NAME
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>A unique name in the Server domain. Required to create a list
+   </td>
+  </tr>
+  <tr>
+   <td>LIST_ADDRESS
+   </td>
+   <td>Yes
+   </td>
+   <td>No
+   </td>
+   <td>No
+   </td>
+   <td>The email address of a list. Returned on Create or Get requests
+   </td>
+  </tr>
+  <tr>
+   <td>DESCRIPTION
+   </td>
+   <td>No
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>Required to create a list
+   </td>
+  </tr>
+  <tr>
+   <td>SUBJECT
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>Required to create a list. Always returned 
+   </td>
+  </tr>
+  <tr>
+   <td>TEMPLATE
+   </td>
+   <td>No
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>Required to create a list
+   </td>
+  </tr>
+  <tr>
+   <td>TOPICS
+   </td>
+   <td>No
+   </td>
+   <td>Yes
+   </td>
+   <td>Yes
+   </td>
+   <td>Required to create a list. The topics must exist in the SYMPA server <strong>topics.conf</strong> file. 
+   </td>
+  </tr>
+  <tr>
+   <td>DOMAIN
+   </td>
+   <td>Yes
+   </td>
+   <td>No
+   </td>
+   <td>No
+   </td>
+   <td>The server’s mail domain. Returned on Create or Get requests
+   </td>
+  </tr>
+</table>
+
+
+
+# 6	Connector Operations
+
+When the **Create List** operation is executed all required attributes must be specified or the operation will fail. If the LIST_NAME already exists on the Sympa server the operation will fail. Once a list has been created it cannot be updated through the connector interface. However the List owner may manually change some attributes such as subject, topics, or description through a SYMPA web interface.
+
+The **GetAll** operation is executed on all queries. The connector returns only the attributes specified in the **IN** column of the schema table.
+
+The **GetOne** operation is executed on a single item lookup. Again only the attributes in the **IN** column are returned.
+
+The **Close List** operation is executed to delete a List. Once a list has been closed it cannot be re-created unless the SYMPA administrator manually purges it’s archive record.  

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# Sympa Connector for Midpoint
+
+
+# SYMPA Connector for Midpoint
 
 
 # 1	Overview
 
 This software is licensed under the terms of [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-This connector uses the Trusted Application interface to interact with a Sympa SOAP service. This interface is described in the Sympa Administration Manual [here](https://sympa-community.github.io/manual/customize/soap-api.html#trust-remote-applications)
+This connector uses the Trusted Application interface to interact with a SYMPA SOAP service. This interface is described in the [SYMPA Administration Manual](https://sympa-community.github.io/manual/customize/soap-api.html#trust-remote-applications).
 
-The current version integrates with a Sympa SOAP service to allow a Midpoint instance to perform the following operations:
+The current version integrates with a SYMPA SOAP service to allow a Midpoint instance to perform the following operations:
 
 
 
@@ -16,15 +18,17 @@ The current version integrates with a Sympa SOAP service to allow a Midpoint ins
 * Get all lists
 * Get one list by list name or list address.
 
+The connector supports the management of Mailing List owners, moderators, and subscribers through an external data source as described below.
+
 
 # 2	Getting Started
 
 
 
-* After installing the Sympa Server you will need to create or modify the _trusted_application.conf_ file to produce an application name, and an application password that can be used to configure the connection.
+* ​​After installing the SYMPA Server you will need to create or modify the _trusted_application.conf_ file to produce an application name, and an application password that can be used to configure the connection.
 * Download the latest version of the connector from this repository.
 * Install and configure the connector into your midpoint instance
-* Create a resource for each Sympa instance that you wish to control
+* Create a resource for each SYMPA instance that you wish to control
 
 
 # 3	Midpoint Setup
@@ -33,10 +37,20 @@ The current version integrates with a Sympa SOAP service to allow a Midpoint ins
 
 * Copy the compiled connector jar file to the _icf-connectors_ subdirectory of your Midpoint instance. This is the connector library folder.
 * Restart midPoint.
-* Within Midpoint create a resource type definition for each Sympa Instance you want to control. Each instance will need its own resource configuration. Make sure to set the fully qualified file location of the configuration file.
+* Within Midpoint, create a resource type definition for each SYMPA Instance you want to control. Each instance will need its own resource configuration.
+* We have included a schema extension to support mapping of SYMPA attributes to Midpoint Organizations
 
 
-# 4	Connector Configuration
+# 4	SYMPA Setup
+
+This connector is designed to work with SYMPA servers that use [SYMPA external Data Sources](https://sympa-community.github.io/manual/customize/data-sources.html) such as LDAP groups to determine the Owners, Moderators, and Subscribers of the Mailing Lists that are created.
+
+The connector relies on the [SYMPA List Creation Template](https://sympa-community.github.io/manual/customize/basics-templates.html) specified at the time of creation to associate the LIST_NAME with its Owners, Moderators, and Subscribers.
+
+You will also need to customize the SYMPA topics.conf file to support the TOPICS attribute that must be specified when you create a list.
+
+
+# 5	Connector Configuration
 
 The connector can be configured by entering the parameters in a property file or by entering the parameters on the Resource Configuration Page.
 
@@ -44,15 +58,15 @@ The following configuration properties are necessary for the connector to operat
 
 
 
-* **app.name** is the trusted application name specified in the target Sympa server's trusted_applications.conf file.
-* **app.password** is the trusted application password specified by the Sympa server's administrator and whose md5 hash is stored in the trusted_applications.conf file.
-* **list.master** is the email address of the list master who is permitted to perform operations executed by the connector. The Sympa administrator should grant the necessary permissions to the email address specified here.
-* **sympa.domain.url** is the url of the Sympa Service you which to control. This url endpoint is typically specified as the port location in the service WSDL.
-* **sympa.domain.wsdl** is the url of the Sympa server's WSDL file. This url should contain the same fully qualified host name as the sympa.domain.url property
-* **CONNECTOR_BASE_CONFIGURATION_ACTIVE** This configuration item originates from the base connector and should be set to Y
+* **app.name** is the trusted application name specified in the target SYMPA server's trusted_applications.conf file.
+* **app.password** is the trusted application password specified by the SYMPA server's administrator and whose md5 hash is stored in the trusted_applications.conf file.
+* **list.master** is the email address of the list master who is permitted to perform operations executed by the connector. The SYMPA administrator should grant the necessary permissions to the email address specified here.
+* **sympa.domain.url** is the url of the SYMPA Service you which to control. This url endpoint is typically specified as the port location in the service WSDL.
+* **sympa.domain.wsdl** is the url of the SYMPA server's WSDL file. This url should contain the same fully qualified host name as the sympa.domain.url property
+* **CONNECTOR_BASE_CONFIGURATION_ACTIVE** This configuration item originates from the base connector and should be set to Y. This value is required when you use a configuration file and set automatically when you use the Resource Configuration page.
 
 
-# 5	Connector Schema
+# 6	Connector Schema
 
 The connector schema consists of the following attributes.
 
@@ -79,7 +93,7 @@ The connector schema consists of the following attributes.
    </td>
    <td>Yes
    </td>
-   <td>A unique name in the Server domain. Required to create a list
+   <td>A unique name in the Server’s DOMAIN. Required to create a list
    </td>
   </tr>
   <tr>
@@ -91,7 +105,7 @@ The connector schema consists of the following attributes.
    </td>
    <td>No
    </td>
-   <td>The email address of a list. Returned on Create or Get requests
+   <td>The email address of a list. Returned on Create or Get requests. This email address is LIST_NAME@DOMAIN. 
    </td>
   </tr>
   <tr>
@@ -127,7 +141,7 @@ The connector schema consists of the following attributes.
    </td>
    <td>Yes
    </td>
-   <td>Required to create a list
+   <td>Required to create a list. Specifies a list creation template that associates the LIST_NAME with owners, moderators, and subscribers.
    </td>
   </tr>
   <tr>
@@ -139,7 +153,7 @@ The connector schema consists of the following attributes.
    </td>
    <td>Yes
    </td>
-   <td>Required to create a list. The topics must exist in the SYMPA server <strong>topics.conf</strong> file. 
+   <td>Required to create a list. The topics specified by this attribute must match ones in the SYMPA server <strong>topics.conf</strong> file. 
    </td>
   </tr>
   <tr>
@@ -158,9 +172,9 @@ The connector schema consists of the following attributes.
 
 
 
-# 6	Connector Operations
+# 7	Connector Operations
 
-When the **Create List** operation is executed all required attributes must be specified or the operation will fail. If the LIST_NAME already exists on the Sympa server the operation will fail. Once a list has been created it cannot be updated through the connector interface. However the List owner may manually change some attributes such as subject, topics, or description through a SYMPA web interface.
+When the **Create List** operation is executed all required attributes must be specified or the operation will fail. If the LIST_NAME already exists on the SYMPA server the operation will fail. Once a list has been created it cannot be updated through the connector interface. However the List owner may manually change some attributes such as subject, topics, or description through a SYMPA web interface.
 
 The **GetAll** operation is executed on all queries. The connector returns only the attributes specified in the **IN** column of the schema table.
 

--- a/artifacts/schema/sympa_org_extension.xsd
+++ b/artifacts/schema/sympa_org_extension.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<xsd:schema elementFormDefault="qualified"
+  targetNamespace="http://sympa.internet2.edu"
+  xmlns:tns="http://grouper-demo.tier.internet2.edu"
+  xmlns:a="http://prism.evolveum.com/xml/ns/public/annotation-3"
+  xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <!-- Extended fields for a midpoint OrgType to support SYMPA Mailing List Server attributes
+         Place this file in your MIDPOINT_HOME/schema directory and restart your midpoint server
+    -->
+    <xsd:complexType name="OrgExtensionType">
+    <xsd:annotation>
+      <xsd:appinfo>
+        <a:extension ref="c:OrgType"/>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:sequence>
+        <xsd:element name="subject" type="xsd:string" minOccurs="0">
+        	<xsd:annotation>
+				<xsd:appinfo>
+					<a:indexed>true</a:indexed>
+					<a:displayName>Subject</a:displayName>
+					<a:help>Typically used as a mailing list subject</a:help>
+				</xsd:appinfo>
+            </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="template" type="xsd:string" minOccurs="0">
+        	<xsd:annotation>
+				<xsd:appinfo>
+					<a:indexed>true</a:indexed>
+					<a:displayName>Template</a:displayName>
+					<a:help>Typically used as a mailing list template for construction</a:help>
+				</xsd:appinfo>
+            </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="topic" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+				<xsd:appinfo>
+					<a:indexed>true</a:indexed>
+					<a:displayName>Topics</a:displayName>
+					<a:help>Typically used to describes the topics covered by the item</a:help>
+				</xsd:appinfo>
+            </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="homepage" type="xsd:string" minOccurs="0">
+            <xsd:annotation>
+                <xsd:appinfo>
+                    <a:indexed>true</a:indexed>
+                    <a:displayName>Home Page</a:displayName>
+                    <a:help>The URL location of the Homepage</a:help>
+   				</xsd:appinfo>
+            </xsd:annotation>
+        </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-project_version=1.0.4
+project_version=1.0.5
 base_version=1.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-project_version=1.0.2
+project_version=1.0.4
 base_version=1.1.3

--- a/src/main/java/com/exclamationlabs/connid/base/sympa/adapter/SympaListsAdapter.java
+++ b/src/main/java/com/exclamationlabs/connid/base/sympa/adapter/SympaListsAdapter.java
@@ -42,16 +42,14 @@ public class SympaListsAdapter extends BaseAdapter<SharedSympaList> {
     @Override
     public List<ConnectorAttribute> getConnectorAttributes() {
         List<ConnectorAttribute> result = new ArrayList<>();
-        result.add(new ConnectorAttribute(HOMEPAGE.name(), STRING));
+        result.add(new ConnectorAttribute(HOMEPAGE.name(), STRING, NOT_UPDATEABLE));
         result.add(new ConnectorAttribute(SUBJECT.name(), STRING));
         result.add(new ConnectorAttribute(LIST_ADDRESS.name(), STRING, NOT_UPDATEABLE));
         result.add(new ConnectorAttribute(LIST_NAME.name(), STRING));
         result.add(new ConnectorAttribute(DESCRIPTION.name(), STRING));
         result.add(new ConnectorAttribute(TEMPLATE.name(), STRING));
         result.add(new ConnectorAttribute(TOPICS.name(), STRING));
-        result.add(new ConnectorAttribute(DOMAIN.name(), STRING));
-        result.add(new ConnectorAttribute(IS_SUBSCRIBER.name(), BOOLEAN));
-        result.add(new ConnectorAttribute(IS_OWNER.name(), BOOLEAN));
+        result.add(new ConnectorAttribute(DOMAIN.name(), STRING, NOT_UPDATEABLE));
         return result;
     }
 

--- a/src/main/java/com/exclamationlabs/connid/base/sympa/configuration/SympaConfiguration.java
+++ b/src/main/java/com/exclamationlabs/connid/base/sympa/configuration/SympaConfiguration.java
@@ -14,13 +14,15 @@
 package com.exclamationlabs.connid.base.sympa.configuration;
 
 import com.exclamationlabs.connid.base.connector.configuration.BaseConnectorConfiguration;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.identityconnectors.framework.spi.ConfigurationClass;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
 
 import java.util.*;
 
 @ConfigurationClass(skipUnsupported = true)
-public class SympaConfiguration extends BaseConnectorConfiguration {
+public class SympaConfiguration extends BaseConnectorConfiguration
+{
 
     public static final String APP_NAME = "app.name";
     public static final String APP_PASSWORD = "app.password";
@@ -28,34 +30,147 @@ public class SympaConfiguration extends BaseConnectorConfiguration {
     public static final String DOMAIN_WSDL = "sympa.domain.wsdl";
     public static final String SYMPA_DOMAIN_URL = "sympa.domain.url";
 
-    public SympaConfiguration() {
+    private String appName;
+    private String appPassword;
+    private String listMaster;
+    private String sympaDomainWSDL;
+    private String sympaDomainURL;
+
+    public SympaConfiguration()
+    {
         super();
+        setConnectorProperties(new Properties());
     }
 
-    public SympaConfiguration(String configurationName) {
+    public SympaConfiguration(String configurationName)
+    {
         super(configurationName);
+        setConnectorProperties(new Properties());
     }
 
     @Override
-    public List<String> getAdditionalPropertyNames() {
-        return Arrays.asList(APP_NAME, APP_PASSWORD, LIST_MASTER,
-                DOMAIN_WSDL, SYMPA_DOMAIN_URL);
+    public List<String> getAdditionalPropertyNames()
+    {
+        return Arrays.asList(APP_NAME, APP_PASSWORD, LIST_MASTER, DOMAIN_WSDL, SYMPA_DOMAIN_URL);
+    }
+
+    @ConfigurationProperty(order = 20, displayMessageKey = "appName.display", helpMessageKey = "appName.help")
+    public String getAppName()
+    {
+        return appName;
+    }
+
+    @ConfigurationProperty(order = 30, displayMessageKey = "appPassword.display", helpMessageKey = "appPassword.help", confidential = true)
+    public String getAppPassword()
+    {
+        return appPassword;
     }
 
     @Override
     @ConfigurationProperty(
-            displayMessageKey = "Sympa Configuration File Path",
-            helpMessageKey = "File path for the Sympa Configuration File",
-            required = true)
-    public String getConfigurationFilePath() {
+            order = 10,
+            displayMessageKey = "configurationFilePath.display",
+            helpMessageKey = "configurationFilePath.help" )
+    public String getConfigurationFilePath()
+    {
         return innerGetMidPointConfigurationFilePath();
     }
 
-    public Map<String, String> getSympaPropertyMap() {
+    @ConfigurationProperty(order = 40, displayMessageKey = "listMaster.display", helpMessageKey = "listMaster.help")
+    public String getListMaster()
+    {
+        return listMaster;
+    }
+
+    @ConfigurationProperty(order = 50, displayMessageKey = "sympaURL.display", helpMessageKey = "sympaURL.help")
+    public String getSympaDomainURL()
+    {
+        return sympaDomainURL;
+    }
+
+    @ConfigurationProperty(order = 60, displayMessageKey = "sympaWSDL.display", helpMessageKey = "sympaWSDL.help")
+    public String getSympaDomainWSDL()
+    {
+        return sympaDomainWSDL;
+    }
+
+    /**
+     * Collect all the Configuration properties
+     * @return Map containing all the configuration properties
+     */
+    public Map<String, String> getSympaPropertyMap()
+    {
         Map<String, String> propertyMap = new HashMap<>();
         getAdditionalPropertyNames().forEach(item ->
                 propertyMap.put(item, getProperty(item)));
         return propertyMap;
     }
 
+    public void setAppName(String appName)
+    {
+        this.appName = appName;
+        forcePropertyCreation();
+        if ( appName != null && appName.trim().length()> 0)
+        {
+            setProperty(APP_NAME, appName);
+        }
+    }
+
+    public void setAppPassword(String appPassword)
+    {
+        this.appPassword = appPassword;
+        forcePropertyCreation();
+        if ( appPassword != null && appPassword.trim().length()> 0)
+        {
+            setProperty(APP_PASSWORD, appPassword);
+        }
+    }
+
+    public void setListMaster(String listMaster)
+    {
+        this.listMaster = listMaster;
+        forcePropertyCreation();
+        if ( listMaster != null && listMaster.trim().length()> 0)
+        {
+            setProperty(LIST_MASTER, listMaster);
+        }
+    }
+
+    public void setSympaDomainURL(String sympaDomainURL)
+    {
+        this.sympaDomainURL = sympaDomainURL;
+        forcePropertyCreation();
+        if ( sympaDomainURL != null && sympaDomainURL.trim().length()> 0)
+        {
+            setProperty(SYMPA_DOMAIN_URL, sympaDomainURL);
+        }
+    }
+
+    public void setSympaDomainWSDL(String sympaDomainWSDL)
+    {
+        this.sympaDomainWSDL = sympaDomainWSDL;
+        forcePropertyCreation();
+        if ( sympaDomainWSDL != null && sympaDomainWSDL.trim().length()> 0)
+        {
+            setProperty(DOMAIN_WSDL, sympaDomainWSDL);
+        }
+    }
+
+    /**
+     * Force connectorProperties creation to ensure setProperty method works
+     */
+    public void forcePropertyCreation()
+    {
+        String propertyFilePath = getConfigurationFilePath();
+
+        if ( propertyFilePath == null || propertyFilePath.trim().length() == 0)
+        {
+            setTestConfiguration();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
 }

--- a/src/main/java/com/exclamationlabs/connid/base/sympa/driver/SympaCore.java
+++ b/src/main/java/com/exclamationlabs/connid/base/sympa/driver/SympaCore.java
@@ -747,10 +747,10 @@ public class SympaCore
         if (obj instanceof SympaFault) {
             SympaFault fault = (SympaFault) obj;
             if (listName != null) {
-                LOG.warn("Failed to complete Sympa request {0} for list {1}. Fault info: {2}.",
+                LOG.info("Failed to complete Sympa request {0} for list {1}. Fault info: {2}.",
                         request, listName, fault.toString());
             } else {
-                LOG.warn("Failed to complete Sympa request {0}. Fault info: {1}.",
+                LOG.info("Failed to complete Sympa request {0}. Fault info: {1}.",
                         request, fault.toString());
             }
             processFault(request, listName, fault);

--- a/src/main/java/com/exclamationlabs/connid/base/sympa/driver/SympaDriver.java
+++ b/src/main/java/com/exclamationlabs/connid/base/sympa/driver/SympaDriver.java
@@ -75,9 +75,12 @@ public class SympaDriver extends BaseDriver
     public void test() throws ConnectorException
     {
         // Test basic connectivity to Sympa by trying to get a dummy list that doesn't exist
-        try {
+        try
+        {
             getSympaCore().getOne("dummyList");
-        } catch (UnknownUidException unk) {
+        }
+        catch (UnknownUidException unk)
+        {
             // expected exception - there should be no dummyList
         }
     }

--- a/src/main/java/com/exclamationlabs/connid/base/sympa/model/SharedSympaList.java
+++ b/src/main/java/com/exclamationlabs/connid/base/sympa/model/SharedSympaList.java
@@ -20,12 +20,8 @@ public class SharedSympaList implements IdentityModel
 {
 
     private String homePage;
-
-
     private String subject;
-
     private String listAddress;
-
     private String listName;
     private String domain;
     private String description;
@@ -74,7 +70,7 @@ public class SharedSympaList implements IdentityModel
                 int at = listAddress.indexOf("@");
                 if ( at > 0 )
                 {
-                    listName = listAddress.substring(at+1);
+                    domain = listAddress.substring(at+1);
                 }
             }
         }

--- a/src/main/resources/com.exclamationlabs.connid.base.sympa/Messages.properties
+++ b/src/main/resources/com.exclamationlabs.connid.base.sympa/Messages.properties
@@ -1,2 +1,0 @@
-sympa.connector.display=Sympa Connector
-basic.group=Basic Configuration Properties

--- a/src/main/resources/com/exclamationlabs/connid/base/sympa/Messages.properties
+++ b/src/main/resources/com/exclamationlabs/connid/base/sympa/Messages.properties
@@ -1,0 +1,20 @@
+sympa.connector.display=Sympa Connector
+basic.group=Basic Configuration Properties
+
+configurationFilePath.display=Paycom Configuration File Path
+configurationFilePath.help=File path for the Paycom Configuration File. This field can be left blank when all parameters are specified on the configuration page.
+
+appName.display=Application Name
+appName.help=Enter the trusted application name specified in the target Sympa server's trusted_applications.conf file.
+
+appPassword.display=Application Password
+appPassword.help=Enter the trusted application password specified by the Sympa server's administrator and whose md5 hash is stored in the trusted_applications.conf file.
+
+listMaster.display=List Master Email Address
+listMaster.help=Enter the List Master's email address. Ensure the List Master is permitted to perform operations executed by the connector.
+
+sympaURL.display=SYMPA Server Domain URL
+sympaURL.help=The URL of the SYMPA Service you wish to control. This URL endpoint is typically specified as the port location in the service WSDL.
+
+sympaWSDL.display=SYMPA Server WDSL URL
+sympaWSDL.help=The URL of the SYMPA server's WSDL file. This URL should contain the same fully qualified host name as the SYMPA Domain URL property


### PR DESCRIPTION
Remove IS_SUBSCRIBER and IS_OWNER attributes since the refer to they the configured list.master and therefore are not relevant. 
Fix the DOMAIN attribute since it was not set on return
Add feature to allow configuration from the Midpoint Resource Configuration Page
Updates the README.md file 